### PR TITLE
chore: remove use of deprecated pkg_resources module

### DIFF
--- a/pytest_drf/__init__.py
+++ b/pytest_drf/__init__.py
@@ -1,6 +1,9 @@
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 
-__version__ = pkg_resources.get_distribution('pytest-drf').version
+try:
+    __version__ = version("pytest-drf")
+except PackageNotFoundError:
+    __version__ = "0.0.0"  # or raise, depending on your preference
 
 
 from .authentication import *

--- a/pytest_drf/__init__.py
+++ b/pytest_drf/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import version, PackageNotFoundError
 try:
     __version__ = version("pytest-drf")
 except PackageNotFoundError:
-    __version__ = "0.0.0"  # or raise, depending on your preference
+    __version__ = '0.0.0-dev'
 
 
 from .authentication import *


### PR DESCRIPTION
setuptools has deprecated and removed the pkg_resources in v82. This uses the more modern importlib tooling.